### PR TITLE
Use of dataType: 'jsonp' also for YouTube

### DIFF
--- a/jquery.lifestream.js
+++ b/jquery.lifestream.js
@@ -709,12 +709,10 @@
     }
 
     $.ajax({
-      url: "http://gdata.youtube.com/feeds/api/users/" + obj.user
+      url: "http://gdata.youtube.com/feeds/api/users/" + obj.user 
         + "/favorites?v=2&alt=jsonc",
+      dataType: 'jsonp',
       success: function(data) {
-        if (typeof data === "string") {
-          data = $.parseJSON(data);
-        }
         callback(parseYoutube(data));
       }
     });


### PR DESCRIPTION
$.parseJSON() gone, now jQuery minumum required version should be < 1.4 (I'm checking...) 
