### PR TITLE
Fixed action name on Wordpress template

### DIFF
--- a/jquery.lifestream.js
+++ b/jquery.lifestream.js
@@ -1365,7 +1365,7 @@
 
     var template = $.extend({},
       {
-        posted: 'bookmarked <a href="${link}">${title}</a>'
+        posted: 'posted <a href="${link}">${title}</a>'
       },
       config.template);
 


### PR DESCRIPTION
A minor issue appeared with implementation of jQuery templates, especially with Wordpress one.
