### PR TITLE
fix blogger and github.

### DIFF
--- a/jquery.lifestream.js
+++ b/jquery.lifestream.js
@@ -189,6 +189,8 @@
               if(item.link[n].rel == 'alternate')
                 item.origLink = item.link[n].href;
             }
+            // ignore items that have no link.
+            if(!item.origLink) continue;
           }
           if(item.title.content) {
             item.title = item.title.content;


### PR DESCRIPTION
It seems a bug in github/blogger.

github: it should pass named object as 'status' to template.
blogger: no such attribute 'origLink'.
