### PR TITLE
GitHub, Tumblr, and StackOverflow enhancements

### DIFF
--- a/jquery.lifestream.js
+++ b/jquery.lifestream.js
@@ -1503,6 +1503,36 @@ $.fn.lifestream.feeds.stackoverflow = function( config, callback ) {
 })(jQuery);(function($) {
 $.fn.lifestream.feeds.tumblr = function( config, callback ) {
 
+  function getImage( post ) {
+    switch(post.type) {
+    case 'photo':
+      var images = post['photo-url'];
+      return $('<img width="75" height="75"/>')
+        .attr({
+          src: images[images.length - 1].content,
+          title: getTitle(post),
+          alt: getTitle(post)
+        }).wrap('<div/>').parent().html(); // generate an HTML string
+    case 'video':
+      var videos = post['video-player'];
+      var video = videos[videos.length - 1].content;
+      // Videos hosted on Tumblr use JavaScript to render the
+      // video, but the JavaScript doesn't work when we call it
+      // from a lifestream - so don't try to embed these.
+      if (video.match(/<\s*script/)) { return null; }
+
+      return video;
+    case 'audio':
+      // Unlike photo and video, audio gives you no visual indication
+      // of what it contains, so we append the "title" text.
+      return post['audio-player'] + ' ' +
+        // HTML-escape the text.
+        $('<div/>').text(getTitle(post)).html();
+    default:
+      return null;
+    }
+  };
+
   function getFirstElementOfBody( post, bodyAttribute ) {
     return $(post[bodyAttribute]).filter(':not(:empty):first').text();
   };
@@ -1565,6 +1595,7 @@ $.fn.lifestream.feeds.tumblr = function( config, callback ) {
       html: $.tmpl( template.posted, {
           type: post.type,
           url: post.url,
+          image: getImage(post),
           title: getTitle(post)
         } )
     };


### PR DESCRIPTION
Here are four changes I made to make these services fit more naturally in my lifestream. Feel free to adopt any or all of them.

StackOverflow messages didn't read like natural language, so mostly I reordered the words.

Full blog entries from Tumblr were too long for the lifestream, so I truncated them. I also added the option of displaying media (photo, video, audio) instead of text.

GitHub just had a bug, I think - when you created a repo, it just said "created" and didn't say _what_ you created.

All these changes worked for me and for some other users I tested on, but obviously I can't guarantee they'll work for everyone.
