### PR TITLE
+ wikipedia language setting

### DIFF
--- a/example.html
+++ b/example.html
@@ -203,9 +203,12 @@
           service: 'vimeo',
           user: 'denbuzze'
         },
+        // [language] Optional setting, defaults to 'en'. 
+        // Use wikipedia local site prefix (e.g. 'de' for German)
         {
           service: 'wikipedia',
-          user: 'Koavf'
+          user: 'Koavf',
+          language: 'en'
         },
         {
           service: 'wordpress',

--- a/src/services/wikipedia.js
+++ b/src/services/wikipedia.js
@@ -1,5 +1,7 @@
 (function($) {
 $.fn.lifestream.feeds.wikipedia = function( config, callback ) {
+  // default to english if no language was set
+  var language = config.language || 'en';
 
   var template = $.extend({},
     {
@@ -8,7 +10,8 @@ $.fn.lifestream.feeds.wikipedia = function( config, callback ) {
     config.template);
 
   $.ajax({
-    url: "http://en.wikipedia.org/w/api.php?action=query&ucuser="
+    url: "http://" + language
+    + ".wikipedia.org/w/api.php?action=query&ucuser="
     + config.user + "&list=usercontribs&ucdir=older&format=json",
     dataType: "jsonp",
     success: function( data ) {
@@ -22,7 +25,7 @@ $.fn.lifestream.feeds.wikipedia = function( config, callback ) {
           
           // Fastest way to get the URL. 
           // Alternatively, we'd have to poll wikipedia for the pageid's link
-          item.url = 'http://en.wikipedia.org/wiki/' 
+          item.url = 'http://' + language + '.wikipedia.org/wiki/' 
           + item.title.replace(' ', '_');
 
           output.push({


### PR DESCRIPTION
Added optional language setting for wikipedia streams. Defaults to English ('en'). The list of codes can be found on [Wikimedia - List of Wikipedias](http://meta.wikimedia.org/wiki/List_of_Wikipedias), the "Wiki" column is needed.

I don't think this requires a new lifestream version, since it is only a minor contribution. 
