### PR TITLE
Add support for FollowEvent

### DIFF
--- a/src/services/github.js
+++ b/src/services/github.js
@@ -31,7 +31,9 @@ $.fn.lifestream.feeds.github = function( config, callback ) {
         +'${status.repository.name}</a>',
       watch: '${status.payload.action} watching <a href="http://github.com/'
         +'${status.repository.owner}/${status.repository.name}">'
-        +'${status.repository.owner}/${status.repository.name}</a>'
+        +'${status.repository.owner}/${status.repository.name}</a>',
+      follow: 'started following <a href="http://github.com/'
+        +'${status.payload.target.login}">${status.payload.target.login}</a>'
     },
     config.template);
 
@@ -133,6 +135,11 @@ $.fn.lifestream.feeds.github = function( config, callback ) {
     }
     else if (status.type === "WatchEvent") {
       return $.tmpl( template.watch, {
+        status: status
+      } );
+    }
+    else if (status.type === "FollowEvent") {
+      return $.tmpl( template.follow, {
         status: status
       } );
     }


### PR DESCRIPTION
There is a slight issue with the FollowEvent. It doesn't have a
payload.action value like many of the other events do. The
payload.action value is supposed to contain a verb that describes the
performed action such as "opened", "closed", "started", "stopped", etc.

Now this isn't _curently_ a problem as the only type of FollowEvents
that show up in the feeds are of the "started" type so the word
"started" can just be hard-coded to replace the missing payload.action
value.

Of course if things change in the future this will need to be changed.
