### PR TITLE
Update StackOverflow config instructions in example.html

### DIFF
--- a/example.html
+++ b/example.html
@@ -205,7 +205,7 @@
           service: 'snipplr',
           user: 'sdxxx'
         },
-        // Run javascript:alert(userid); when you're logged in at stackoverflow
+        // Log in, click username, copy second-to-last portion of URL (digits)
         {
           service: 'stackoverflow',
           user: '117193'


### PR DESCRIPTION
SO config example in example.html no work-y (Chrome swallows javascript: command; nothing happens  in Safari). Suggest change to manual SO ID retrieval.
