### PR TITLE
Upgrade to UglifyJS2

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Use `make target` and replace _target_ with the target you want to use.
 
 * [Node](https://github.com/joyent/node/wiki/Installation)
 * [Npm](http://npmjs.org/)
-* [UglifyJS](https://github.com/mishoo/UglifyJS/)
+* [UglifyJS 2](https://github.com/mishoo/UglifyJS2)
 
 ## Usage
 

--- a/build/Makefile
+++ b/build/Makefile
@@ -16,27 +16,27 @@ script_min = ../download/js/script.min.js
 all: jls jls-min uglifyjs uglifyjs-min service-list script-min
 
 jls: $(jls)
-	
+
 jls-min: $(jls_min)
-	
+
 uglifyjs: $(uglifyjs)
-	
+
 uglifyjs-min: $(uglifyjs_min)
-	
+
 script-min: $(script_min)
-	
+
 service-list:
 	@echo "Building $(service_list)"
 	@node service-list.js $(services) > $(service_list)
-	
+
 $(jls): $(modules) | $(main)
 	@echo "Building $@"
 	@cat $^ > $@
 
 $(jls_min): $(jls)
 	@echo "Building $@"
-	@uglifyjs $^ > $@
-	
+	@uglifyjs $^ --compress --mangle --comments > $@
+
 $(uglifyjs): uglifyjs-cs-prologue.js parse-js-prologue.js parse-js.js \
 parse-js-epilogue.js process-prologue.js process.js process-epilogue.js \
 squeeze-more-prologue.js squeeze-more.js squeeze-more-epilogue.js \
@@ -46,8 +46,8 @@ uglifyjs-cs-epilogue.js
 
 $(uglifyjs_min): $(uglifyjs)
 	@echo "Building $@"
-	@uglifyjs $^ > $@
-	
+	@uglifyjs $^ --compress --mangle --comments > $@
+
 $(script_min): $(script)
 	@echo "Building $@"
-	@uglifyjs $^ > $@
+	@uglifyjs $^ --compress --mangle --comments > $@

--- a/src/core.js
+++ b/src/core.js
@@ -1,9 +1,10 @@
 /*!
  * jQuery Lifestream Plug-in
- * @version 0.4.0
  * Show a stream of your online activity
- *
- * Copyright 2011, Christian Vuerings - http://denbuzze.com
+ * @version   0.4.0
+ * @author    Christian Vuerings et al.
+ * @copyright Copyright 2011, Christian Vuerings - http://denbuzze.com
+ * @license   https://github.com/christianv/jquery-lifestream/blob/master/LICENSE MIT
  */
 /*global jQuery */
 ;(function( $ ){


### PR DESCRIPTION
Updated the build process to use UglifyJS 2 parameters (per issue #129). That is,  if you install it via `npm install uglifyjs`, that already is uglifyjs2.

The main difference for us is the way it encodes comments, i.e. requiring `@preserve` or `@license` according to JSDoc. Thus I updated the core comment according to JSDoc syntax and added 'et al.' to `@author`. I hope you don't mind, it just seemed polite.

The empty modified lines are in the diff because my editor automatically removes them (I told it too, makes life easier in the long run).
