### PR TITLE
Generate lifestream.css on build

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Use `make target` and replace _target_ with the target you want to use.
   Build jquery.lifestream.js, the non-minified version of jQuery Lifestream
 * **jls-min**: 
   Build jquery.lifestream.min.js, the minified version of jQuery Lifestream
+* **jls-css**:
+  Build css/lifestream.css, the stylesheet containing the favicons
 * **script-min**:
   Build download/js/script.min.js, this script is the main script for the
   download page
@@ -183,12 +185,10 @@ For more information about each _service_, check out the [source code][exampleso
 Adding in your own feed is pretty easy.  
 Have a look at [this commit](https://github.com/christianv/jquery-lifestream/commit/529a06db159b4123ee3b2cc604f3a3ed698c6e9a) which adds support for the last.fm feed.
 
-### Create data:URI for an icon
+### Add your favicon
 
 1. [Convert](http://converticon.com/) the favicon.ico of a site to a .png file. (e.g. http://google.com/favicon.ico)
 2. [Optimize](http://www.smushit.com/ysmush.it/) the .png file. Save it in src/favicons/.
-3. [Make](http://www.dopiaza.org/tools/datauri/) a data:URI for it.
-4. Put the data:URI in css/lifestream.css (alphabetical order).
 
 ### How to commit?
 

--- a/build/Makefile
+++ b/build/Makefile
@@ -1,24 +1,30 @@
 src = ../src
 services = $(src)/services
+favicons = $(src)/favicons
 build = .
 main = ..
 modules = $(src)/core.js $(services)/*.js
 service_list = ../download/services.json
 jls = $(main)/jquery.lifestream.js
 jls_min = $(main)/jquery.lifestream.min.js
+jls_css = $(main)/css/lifestream.css
 uglifyjs = ../download/js/uglifyjs-cs.js
 uglifyjs_min = ../download/js/uglifyjs-cs.min.js
 script = ../download/js/script.js
 script_min = ../download/js/script.min.js
 
-.PHONY: all jls jls-min uglifyjs uglifyjs-min service-list script-min
+.PHONY: all jls jls-min jls-css uglifyjs uglifyjs-min service-list script-min
 
-all: jls jls-min uglifyjs uglifyjs-min service-list script-min
+all: jls jls-min jls-css uglifyjs uglifyjs-min service-list script-min
 
 jls: $(jls)
 	
 jls-min: $(jls_min)
 	
+jls-css:
+	@echo "Building $@"
+	@node compile-css.js $(favicons) > $(jls_css)
+
 uglifyjs: $(uglifyjs)
 	
 uglifyjs-min: $(uglifyjs_min)

--- a/build/compile-css.js
+++ b/build/compile-css.js
@@ -1,0 +1,36 @@
+/* jshint node:true */
+var fs = require('fs'),
+  path = require('path'),
+  baseDir = process.argv[2],
+  files = [],
+  styles = '';
+
+// get the mime type base on extension
+// easier than installing modules, but more accident-prone
+var getMimeType = function(filepath) {
+  var types = {
+    'gif': 'image/gif',
+    'jpe': 'image/jpeg',
+    'jpg': 'image/jpeg',
+    'jpeg': 'image/jpeg',
+    'png': 'image/png'
+  },
+  extension = path.extname(filepath).replace('.', '');
+
+  return types[extension];
+};
+
+// gets an image and gives you the full css class
+var base64Encode = function(filepath) {
+  return '.lifestream-' + path.basename(filepath, path.extname(filepath)) +
+    '{background-image:url(data:' + getMimeType(filepath) +
+    ';base64,' + fs.readFileSync(filepath).toString('base64') +
+    ')}';
+};
+
+files = fs.readdirSync(baseDir);
+files.sort().forEach(function(filename){
+  styles += base64Encode( baseDir + '/' + filename ) + "\n";
+});
+
+process.stdout.write(styles);


### PR DESCRIPTION
This was a pet peeve of mine actually. Basically this enables us to base64 encode the images upon build, removing a few contribution steps and making it easier to add a service (I know, not our biggest concern). I eventually did it because I saw the mendeley icon was missing for some reason.

In the future it might be nice to also optimize the images before encoding, though I'll have to research this a bit.
