### PR TITLE
fix twitter hashtag search

### DIFF
--- a/jquery.lifestream.js
+++ b/jquery.lifestream.js
@@ -2359,7 +2359,7 @@ $.fn.lifestream.feeds.tumblr = function( config, callback ) {
         return t.replace(
           /(^|[^\w'"]+)\#([a-zA-Z0-9ÅåÄäÖöØøÆæÉéÈèÜüÊêÛûÎî_]+)/g,
           function( m, m1, m2 ) {
-            return m1 + '<a href="http://search.twitter.com/search?q=%23' +
+            return m1 + '<a href="http://www.twitter.com/search?q=%23' +
             m2 + '">#' + m2 + '</a>';
           }
         );


### PR DESCRIPTION
click on twitter hashtag will go to http://search.twitter.com/search?q=%23hashtag
which shows

```
The Twitter REST API v1 is no longer active. Please migrate to API v1.1.
https://dev.twitter.com/docs/api/1.1/overview
```
