### PR TITLE
twitter.js: linkify: detect links with #

### DIFF
--- a/src/services/twitter.js
+++ b/src/services/twitter.js
@@ -21,7 +21,7 @@
 
       var link = function( t ) {
         return t.replace(
-          /[a-z]+:\/\/[a-z0-9\-_]+\.[a-z0-9\-_:~%&\?\/.=]+[^:\.,\)\s*$]/ig,
+          /([a-z]+:\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/ig,
           function( m ) {
             return '<a href="' + m + '">' +
               ( ( m.length > 25 ) ? m.substr( 0, 24 ) + '...' : m ) +


### PR DESCRIPTION
## Problem

Links with a hash sign are not identified correctly.
## Example

http://christianv.github.io/jquery-lifestream/me/#twitter=ahtanu (the link with google maps preview) 
![image 2014-02-05 at 12 58 12 pm](https://f.cloud.github.com/assets/817381/2086687/dd6dd5fa-8e5c-11e3-9dd4-9857b2ff37f3.png)
## Fix

Replaced the regular expression with one that can identify these kind of links.

Twitter also provides a library to parse text, might be a better/more robust solution to parse tweets: https://github.com/twitter/twitter-text-js
