### PR TITLE
using tweet url instead of user url

### DIFF
--- a/src/services/twitter.js
+++ b/src/services/twitter.js
@@ -71,7 +71,8 @@
             "complete_url": 'http://twitter.com/' + config.user +
               "/status/" + status.id_str
           } ),
-          "url": 'http://twitter.com/' + config.user
+          "url": 'http://twitter.com/' + config.user +
+              "/status/" + status.id_str
         });
       }
 


### PR DESCRIPTION
so that url of each tweet can bind to each `li` in `ul`
