### PR TITLE
Use SSL by default on ajax requests. Closes #173

### DIFF
--- a/src/services/reddit.js
+++ b/src/services/reddit.js
@@ -45,7 +45,7 @@ $.fn.lifestream.feeds.reddit = function( config, callback ) {
   };
 
   $.ajax({
-    url: "http://www.reddit.com/user/" + config.user + ".json",
+    url: "https://pay.reddit.com/user/" + config.user + ".json",
     dataType: "jsonp",
     jsonp:"jsonp",
     success: function( data ) {


### PR DESCRIPTION
www.reddit.com doesn't support SSL, so switched ajax request to pay.reddit.com
